### PR TITLE
Multiple changes to `getConsentMetadata`

### DIFF
--- a/docs/global.html
+++ b/docs/global.html
@@ -1207,7 +1207,7 @@ user denies, use <code>ConsentTypes.DENY</code>.</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line185">line 185</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line187">line 187</a>
         </li>
       </ul>
     </dd>
@@ -1388,7 +1388,7 @@ user denies, use <code>ConsentTypes.DENY</code>.</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line162">line 162</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line164">line 164</a>
         </li>
       </ul>
     </dd>
@@ -1662,7 +1662,7 @@ user.</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line144">line 144</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line146">line 146</a>
         </li>
       </ul>
     </dd>
@@ -1901,7 +1901,7 @@ request. If they continue past the consent page, the consent is recorded.</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line201">line 201</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line203">line 203</a>
         </li>
       </ul>
     </dd>
@@ -2054,7 +2054,7 @@ to the default purpose-aware attribute category</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line113">line 113</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line115">line 115</a>
         </li>
       </ul>
     </dd>
@@ -2440,6 +2440,8 @@ a EULA.</p>
 <br><code>NONE</code> - No consent
 <br><code>ACTIVE</code> - An active consent record exists. However, the
 consent may not translate to &quot;yes&quot;.
+<br><code>NOT_ACTIVE</code> - A user consent record exists but the start
+time is in the future.
 <br><code>EXPIRED</code> - A user consent record exists but it is no longer
 valid. This may be due to a new privacy rule or a change in configuration or
 the consent has lapsed.</p>
@@ -3034,7 +3036,7 @@ the data was received or not.
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line133">line 133</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line135">line 135</a>
         </li>
       </ul>
     </dd>
@@ -3217,7 +3219,7 @@ on whether the data was received or not.
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line122">line 122</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line124">line 124</a>
         </li>
       </ul>
     </dd>
@@ -3403,7 +3405,7 @@ This should be consulted when the status is <code>fail</code></p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line171">line 171</a>
+          <a href="utils_jsdoc_privacyTypeDefs.js.html">utils/jsdoc/privacyTypeDefs.js</a>, <a href="utils_jsdoc_privacyTypeDefs.js.html#line173">line 173</a>
         </li>
       </ul>
     </dd>

--- a/docs/module-Privacy-Privacy.html
+++ b/docs/module-Privacy-Privacy.html
@@ -779,7 +779,7 @@ const client = new Privacy({
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line327">line 327</a>
+          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line337">line 337</a>
         </li>
       </ul>
     </dd>
@@ -1018,7 +1018,7 @@ const client = new Privacy({
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line339">line 339</a>
+          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line349">line 349</a>
         </li>
       </ul>
     </dd>
@@ -1616,6 +1616,37 @@ if no attributes are configured for the purpose. Wildcards are not allowed.</p>
       </tr>
 
     
+      <tr>
+        
+          <td class="name"><code>attributeValue</code></td>
+        
+
+        <td class="type">
+          
+            
+    <span class="param-type">
+      string
+    </span>
+
+    
+
+
+          
+        </td>
+
+        
+
+        
+
+        <td class="description last">
+          <p>The attribute value for the attribute.
+This is typically used when the user has more than one value for the
+attribute. This is optional.</p>
+          
+        </td>
+      </tr>
+
+    
   </tbody>
 </table>
 
@@ -1699,7 +1730,7 @@ and any consent metadata</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line199">line 199</a>
+          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line202">line 202</a>
         </li>
       </ul>
     </dd>
@@ -1857,7 +1888,7 @@ if (r.status == "done") {
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line252">line 252</a>
+          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line262">line 262</a>
         </li>
       </ul>
     </dd>
@@ -2062,7 +2093,7 @@ created or updated</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line299">line 299</a>
+          <a href="privacy.js.html">privacy.js</a>, <a href="privacy.js.html#line309">line 309</a>
         </li>
       </ul>
     </dd>

--- a/docs/privacy.js.html
+++ b/docs/privacy.js.html
@@ -257,6 +257,9 @@ class Privacy {
    * @param {string} items.attributeId The attribute ID on Verify. This must be
    * configured as one of the attributes for the purpose. This may be optional
    * if no attributes are configured for the purpose. Wildcards are not allowed.
+   * @param {string} items.attributeValue The attribute value for the attribute.
+   * This is typically used when the user has more than one value for the
+   * attribute. This is optional.
    *
    * @return {Promise&lt;WrappedMetadata>} The status of the request
    * and any consent metadata
@@ -286,7 +289,7 @@ class Privacy {
     try {
       // retrieve the list of purposes
       const purposes = new Set();
-      const itemNameSet = new Set();
+      const itemFilter = {};
       for (const item of items) {
         purposes.add(item.purposeId);
 
@@ -294,9 +297,16 @@ class Privacy {
           item.accessTypeId = 'default';
         }
 
-        itemNameSet.add(item.purposeId + '/' +
+        const itemKey = item.purposeId + '/' +
             StringUtils.getOrDefault(item, 'attributeId', '') +
-            '.' + StringUtils.getOrDefault(item, 'accessTypeId', ''));
+            '.' + StringUtils.getOrDefault(item, 'accessTypeId', '');
+        const attrValue = StringUtils.getOrDefault(item, 'attributeValue', '');
+        if (!itemFilter.hasOwnProperty(itemKey)) {
+          // initialize
+          itemFilter[itemKey] = [attrValue];
+        } else {
+          itemFilter[itemKey].push(attrValue);
+        }
       }
 
       // get metadata
@@ -305,7 +315,7 @@ class Privacy {
 
       // filter and normalize
       const metadata = await service.processConsentMetadata(
-          itemNameSet, response);
+          itemFilter, response);
       debug(`[${methodName}]`, 'metadata:', JSON.stringify(metadata));
 
       return {status: 'done', metadata};

--- a/docs/utils_jsdoc_privacyTypeDefs.js.html
+++ b/docs/utils_jsdoc_privacyTypeDefs.js.html
@@ -186,6 +186,8 @@
  * &lt;br>&lt;code>NONE&lt;/code> - No consent
  * &lt;br>&lt;code>ACTIVE&lt;/code> - An active consent record exists. However, the
  * consent may not translate to "yes".
+ * &lt;br>&lt;code>NOT_ACTIVE&lt;/code> - A user consent record exists but the start
+ * time is in the future.
  * &lt;br>&lt;code>EXPIRED&lt;/code> - A user consent record exists but it is no longer
  * valid. This may be due to a new privacy rule or a change in configuration or
  * the consent has lapsed.

--- a/lib/privacy.js
+++ b/lib/privacy.js
@@ -174,6 +174,9 @@ class Privacy {
    * @param {string} items.attributeId The attribute ID on Verify. This must be
    * configured as one of the attributes for the purpose. This may be optional
    * if no attributes are configured for the purpose. Wildcards are not allowed.
+   * @param {string} items.attributeValue The attribute value for the attribute.
+   * This is typically used when the user has more than one value for the
+   * attribute. This is optional.
    *
    * @return {Promise<WrappedMetadata>} The status of the request
    * and any consent metadata
@@ -203,7 +206,7 @@ class Privacy {
     try {
       // retrieve the list of purposes
       const purposes = new Set();
-      const itemNameSet = new Set();
+      const itemFilter = {};
       for (const item of items) {
         purposes.add(item.purposeId);
 
@@ -211,9 +214,16 @@ class Privacy {
           item.accessTypeId = 'default';
         }
 
-        itemNameSet.add(item.purposeId + '/' +
+        const itemKey = item.purposeId + '/' +
             StringUtils.getOrDefault(item, 'attributeId', '') +
-            '.' + StringUtils.getOrDefault(item, 'accessTypeId', ''));
+            '.' + StringUtils.getOrDefault(item, 'accessTypeId', '');
+        const attrValue = StringUtils.getOrDefault(item, 'attributeValue', '');
+        if (!itemFilter.hasOwnProperty(itemKey)) {
+          // initialize
+          itemFilter[itemKey] = [attrValue];
+        } else {
+          itemFilter[itemKey].push(attrValue);
+        }
       }
 
       // get metadata
@@ -222,7 +232,7 @@ class Privacy {
 
       // filter and normalize
       const metadata = await service.processConsentMetadata(
-          itemNameSet, response);
+          itemFilter, response);
       debug(`[${methodName}]`, 'metadata:', JSON.stringify(metadata));
 
       return {status: 'done', metadata};

--- a/lib/services/dpcm/dpcmService.js
+++ b/lib/services/dpcm/dpcmService.js
@@ -176,14 +176,15 @@ class DPCMService extends Service {
   /**
    * Processes the DSP API response into a flatter representation for ease
    * of consumption.
-   * @param {Set} itemSet A set of items that were used to call the
+   * @param {Object} itemFilter A set of items that were used to call the
    * <code>getConsentMetadata</code> function. The request items are
-   * serialized as <code>purposeID/attributeID.accessTypeID</code>.
+   * serialized as <code>purposeID/attributeID.accessTypeID</code> with
+   * value as a set of attribute values.
    * @param {*} response The DSP response
    * @return {Promise<Object>} The promise object that evaluates to the
    * flattened result.
    */
-  async processConsentMetadata(itemSet, response) {
+  async processConsentMetadata(itemFilter, response) {
     const metadata = {
       eula: [],
       default: [],
@@ -197,52 +198,51 @@ class DPCMService extends Service {
       }
 
       const purpose = response.purposes[purposeID];
+      const metadataRecords = (purpose.category == 'eula') ?
+            metadata.eula : metadata.default;
+      const metadataBuilder = async (attribute, accessType) => {
+        const attrID = (attribute != null) ? attribute.id : '';
+        const name = `${purposeID}/${attrID}.${accessType.id}`;
+        let attrValues = null;
+        if (name in itemFilter) {
+          attrValues = itemFilter[name];
+        } else if (attribute != null) {
+          // the client may have used the name instead of ID
+          const attrName = response.attributes[attrID].name;
+          const alias = `${purposeID}/${attrName}.${accessType.id}`;
+          if (alias in itemFilter) {
+            attrValues = itemFilter[alias];
+          }
+        }
+
+        if (attrValues == null) {
+          debug(`Ignoring ${name}`);
+          return;
+        }
+
+        debug(`Eval ${name}`);
+        this._buildMetadataRecords(response, purpose,
+            attrID, accessType.id,
+            (accessType.assentUIDefault) ? accessType.assentUIDefault : false,
+            (accessType.legalCategory) ? accessType.legalCategory : 4,
+            attrValues,
+            (attrValue, record) => {
+              metadataRecords.push(record);
+              const key = `${name}#${attrValue}`;
+              records[key] = record;
+            });
+      };
+
       if (purpose.attributes && Array.isArray(purpose.attributes)) {
         for (const attribute of purpose.attributes) {
-          const attributeID = attribute.id;
           for (const accessType of attribute.accessTypes) {
-            const name = `${purposeID}/${attributeID}.${accessType.id}`;
-            if (!itemSet.has(name)) {
-              // the client may have used the name instead of ID
-              const attrName = response.attributes[attributeID].name;
-              const alias = `${purposeID}/${attrName}.${accessType.id}`;
-              if (!itemSet.has(alias)) {
-                debug(`Ignoring ${name}`);
-                continue;
-              }
-            }
-
-            debug(`Eval ${name}`);
-
-            const record = await this._buildMetadataRecord(response, purpose,
-                attributeID, accessType.id, accessType.assentUIDefault,
-                accessType.legalCategory);
-            records[name] = record;
-            if (purpose.category === 'eula') {
-              metadata.eula.push(record);
-            } else {
-              metadata.default.push(record);
-            }
+            await metadataBuilder(attribute, accessType);
           }
         }
       } else {
         // use access types
         for (const accessType of purpose.accessTypes) {
-          const name = `${purposeID}/.${accessType.id}`;
-          if (!itemSet.has(name)) {
-            continue;
-          }
-
-          const record = await this._buildMetadataRecord(response, purpose,
-              null, accessType.id,
-              (accessType.assentUIDefault) ? accessType.assentUIDefault : false,
-              (accessType.legalCategory) ? accessType.legalCategory : 4);
-          records[name] = record;
-          if (purpose.category === 'eula') {
-            metadata.eula.push(record);
-          } else {
-            metadata.default.push(record);
-          }
+          await metadataBuilder(null, accessType);
         }
       }
     }
@@ -257,14 +257,27 @@ class DPCMService extends Service {
       const attrId = StringUtils.getOrDefault(consent, 'attributeId', '');
       const accessTypeId = StringUtils.getOrDefault(
           consent, 'accessTypeId', '');
-      const name = `${consent.purposeId}/${attrId}.${accessTypeId}`;
+      const attrValue = StringUtils.getOrDefault(consent, 'attributeValue', '');
+      const name =
+          `${consent.purposeId}/${attrId}.${accessTypeId}#${attrValue}`;
       if (!records[name] || records[name] == null) {
         continue;
       }
 
       const record = records[name];
+      if (record.consent && record.consent != null &&
+          !record.consent.isGlobal) {
+        // app specific consent already exists
+        continue;
+      }
       record.consent = consent;
-      record.status = (consent.status == 1) ? 'ACTIVE' : 'EXPIRED';
+      if (consent.status == 1) {
+        record.status = 'ACTIVE';
+      } else if (consent.status == 3) {
+        record.status = 'NOT_ACTIVE';
+      } else {
+        record.status = 'EXPIRED';
+      }
     }
 
     return metadata;
@@ -364,27 +377,34 @@ class DPCMService extends Service {
    * consent is assented
    * @param {number} legalCategory The legal category that translates
    * to consent display type
-   * @return {Object} The flattened metadata record
+   * @param {Array} attrValues The attribute values that are of interest
+   * @param {Function} commitFn Storage function to store the record
    */
-  async _buildMetadataRecord(response, purpose, attributeID, accessTypeID,
-      assentUIDefault, legalCategory) {
+  async _buildMetadataRecords(response, purpose, attributeID, accessTypeID,
+      assentUIDefault, legalCategory, attrValues, commitFn) {
     const attrName = (attributeID != null) ?
         response.attributes[attributeID].name : null;
     const termsOfUseRef = (purpose.termsOfUse && purpose.termsOfUse.ref) ?
         purpose.termsOfUse.ref : null;
-    return {
-      purposeId: purpose.id,
-      attributeId: attributeID,
-      accessTypeId: accessTypeID,
-      purposeName: purpose.name,
-      attributeName: attrName,
-      accessType: response.accessTypes[accessTypeID].name,
-      defaultConsentDuration: purpose.defaultConsentDuration,
-      assentUIDefault: assentUIDefault,
-      consentType: legalCategory,
-      termsOfUseRef: termsOfUseRef,
-      status: 'NONE',
-    };
+
+    for (const attrValue of attrValues) {
+      const record = {
+        purposeId: purpose.id,
+        attributeId: attributeID,
+        accessTypeId: accessTypeID,
+        purposeName: purpose.name,
+        attributeName: attrName,
+        accessType: response.accessTypes[accessTypeID].name,
+        attributeValue: (attrValue != '') ? attrValue : null,
+        defaultConsentDuration: purpose.defaultConsentDuration,
+        assentUIDefault: assentUIDefault,
+        consentType: legalCategory,
+        termsOfUseRef: termsOfUseRef,
+        status: 'NONE',
+      };
+
+      commitFn(attrValue, record);
+    }
   }
 }
 

--- a/lib/services/dpcm/dpcmService.js
+++ b/lib/services/dpcm/dpcmService.js
@@ -109,7 +109,9 @@ class DPCMService extends Service {
           // Rule decision is deny.
           // The input application {{appID}} to purpose mapping {{purpose}}
           // is not valid.
-          if (!['CSIBT0040I', 'CSIBT0041I', 'CSIBT0060I', 'CSIBT0016E']
+          // The purpose is either invalid or has no active version.
+          if (!['CSIBT0040I', 'CSIBT0041I', 'CSIBT0060I',
+            'CSIBT0016E', 'CSIBT0022E']
               .includes(iaresult.reason.messageId)) {
             // at least one item requires consent
             status = 'consent';

--- a/lib/utils/jsdoc/privacyTypeDefs.js
+++ b/lib/utils/jsdoc/privacyTypeDefs.js
@@ -103,6 +103,8 @@
  * <br><code>NONE</code> - No consent
  * <br><code>ACTIVE</code> - An active consent record exists. However, the
  * consent may not translate to "yes".
+ * <br><code>NOT_ACTIVE</code> - A user consent record exists but the start
+ * time is in the future.
  * <br><code>EXPIRED</code> - A user consent record exists but it is no longer
  * valid. This may be due to a new privacy rule or a change in configuration or
  * the consent has lapsed.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "testdebug": "DEBUG=verify:* mocha test/service/*.js test/privacy/*.js --timeout 5000",
     "test": "mocha test/service/*.js test/privacy/*.js --timeout 5000",
+    "testwithfiles": "mocha --timeout 5000",
     "clean": "rm -r node_modules package-lock.json",
     "docs": "rm -r docs 2>/dev/null; jsdoc -c ./.jsdoc.json --verbose",
     "check-env": "node -e 'console.log(process.env)' | grep npm",
@@ -21,9 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.21.1",
-    "debug": "^4.3.1",
-    "dotenv": "^10.0.0",
-    "jsdoc-fresh": "^1.1.0"
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "docdash": "^1.2.0",
@@ -31,6 +30,8 @@
     "eslint-config-google": "^0.14.0",
     "jsdoc": "^3.6.6",
     "minami": "^1.2.3",
-    "mocha": "^8.3.0"
+    "mocha": "^8.3.0",
+    "jsdoc-fresh": "^1.1.0",
+    "dotenv": "^10.0.0"
   }
 }

--- a/test/privacy/assessTest.js
+++ b/test/privacy/assessTest.js
@@ -90,5 +90,19 @@ describe('Privacy', () => {
         assert.fail(`Error thrown:\n${error}`);
       }
     });
+
+    it('badeula', async () => {
+      const client = new Privacy(config, auth, context);
+
+      const result = await client.assess([
+        {
+          'purposeId': 'badeula',
+        },
+      ]);
+
+      debug(`result =\n${JSON.stringify(result)}`);
+      assert.strictEqual(result.status, 'denied',
+          `Result status is not error: ${JSON.stringify(result)}`);
+    });
   });
 });

--- a/test/privacy/consentMetadataTest.js
+++ b/test/privacy/consentMetadataTest.js
@@ -4,16 +4,49 @@ const config = Env.Config; const auth = Env.Auth; const context = Env.Context;
 const Privacy = require('../../lib/privacy');
 
 describe('Privacy', () => {
-  before((done) => {
+  before( async () => {
     if (!config.tenantUrl || config.tenantUrl == '') {
-      return done('TENANT_URL is missing from the env');
+      throw new Error('TENANT_URL is missing from the env');
     }
 
     if (!auth.accessToken || auth.accessToken == '') {
-      return done('ACCESS_TOKEN is missing from the env');
+      throw new Error('ACCESS_TOKEN is missing from the env');
     }
 
-    return done();
+    // precreate some consents
+    const client = new Privacy(config, auth, context);
+    await client.storeConsents([
+      {
+        // Consent with attribute value
+        'purposeId': 'profilemgmt',
+        'attributeId': 'mobile_number',
+        'attributeValue': '+651234567',
+        'accessTypeId': 'read',
+        'state': 3,
+      },
+      {
+        // Consent without attribute value
+        'purposeId': 'profilemgmt',
+        'attributeId': 'given_name',
+        'accessTypeId': 'read',
+        'state': 3,
+      },
+      {
+        // Consent that is in the future
+        'purposeId': 'profilemgmt',
+        'attributeId': 'display_name',
+        'accessTypeId': 'read',
+        'state': 3,
+        'startTime': 1749508768,
+      },
+      {
+        // Opt out
+        'purposeId': 'profilemgmt',
+        'attributeId': 'family_name',
+        'accessTypeId': 'read',
+        'state': 4,
+      },
+    ]);
   });
 
   describe('#consentMetadata', () => {
@@ -23,9 +56,9 @@ describe('Privacy', () => {
       try {
         const result = await client.getConsentMetadata([
           {
-            'purposeId': 'marketing',
-            'attributeId': 'mobile_number', // mobile_number
-            'accessTypeId': 'default',
+            'purposeId': 'profilemgmt',
+            'attributeId': 'given_name',
+            'accessTypeId': 'read',
           },
         ]);
 
@@ -43,7 +76,7 @@ describe('Privacy', () => {
         const result = await client.getConsentMetadata([
           {
             'purposeId': 'marketing',
-            'attributeId': 'mobile_number', // mobile_number
+            'attributeId': 'given_name',
             'accessTypeId': 'default',
           },
           {
@@ -52,6 +85,42 @@ describe('Privacy', () => {
         ]);
 
         assert.strictEqual(result.status, 'error',
+            `Result status is not done: ${result.status}`);
+      } catch (error) {
+        assert.fail(`Error thrown:\n${error}`);
+      }
+    });
+
+    it('deep test', async () => {
+      const client = new Privacy(config, auth, context);
+
+      try {
+        const result = await client.getConsentMetadata([
+          {
+            'purposeId': 'profilemgmt',
+            'attributeId': 'given_name',
+            'accessTypeId': 'read',
+          },
+          {
+            'purposeId': 'profilemgmt',
+            'attributeId': 'mobile_number',
+            'attributeValue': '+6598786',
+            'accessTypeId': 'read',
+          },
+          {
+            'purposeId': 'profilemgmt',
+            'attributeId': 'mobile_number',
+            'attributeValue': '+651234567',
+            'accessTypeId': 'read',
+          },
+          {
+            'purposeId': 'profilemgmt',
+            'attributeId': 'display_name',
+            'accessTypeId': 'read',
+          },
+        ]);
+
+        assert.strictEqual(result.status, 'done',
             `Result status is not done: ${result.status}`);
       } catch (error) {
         assert.fail(`Error thrown:\n${error}`);

--- a/test/privacy/consentMetadataTest.js
+++ b/test/privacy/consentMetadataTest.js
@@ -53,77 +53,92 @@ describe('Privacy', () => {
     it('get some metadata', async () => {
       const client = new Privacy(config, auth, context);
 
-      try {
-        const result = await client.getConsentMetadata([
-          {
-            'purposeId': 'profilemgmt',
-            'attributeId': 'given_name',
-            'accessTypeId': 'read',
-          },
-        ]);
+      const result = await client.getConsentMetadata([
+        {
+          'purposeId': 'profilemgmt',
+          'attributeId': 'given_name',
+          'accessTypeId': 'read',
+        },
+      ]);
 
-        assert.strictEqual(result.status, 'done',
-            `Result status is not done: ${result.status}`);
-      } catch (error) {
-        assert.fail(`Error thrown:\n${error}`);
-      }
+      assert.strictEqual(result.status, 'done',
+          `Result status is not done: ${result.status}`);
     });
 
     it('get error because of invalid purpose', async () => {
       const client = new Privacy(config, auth, context);
 
-      try {
-        const result = await client.getConsentMetadata([
-          {
-            'purposeId': 'marketing',
-            'attributeId': 'given_name',
-            'accessTypeId': 'default',
-          },
-          {
-            'purposeId': '98b56762-398b-4116-94b5-125b5ca0d831',
-          },
-        ]);
+      const result = await client.getConsentMetadata([
+        {
+          'purposeId': 'marketing',
+          'attributeId': 'given_name',
+          'accessTypeId': 'default',
+        },
+        {
+          'purposeId': '98b56762-398b-4116-94b5-125b5ca0d831',
+        },
+      ]);
 
-        assert.strictEqual(result.status, 'error',
-            `Result status is not done: ${result.status}`);
-      } catch (error) {
-        assert.fail(`Error thrown:\n${error}`);
-      }
+      assert.strictEqual(result.status, 'error',
+          `Result status is not done: ${result.status}`);
     });
 
     it('deep test', async () => {
       const client = new Privacy(config, auth, context);
 
-      try {
-        const result = await client.getConsentMetadata([
-          {
-            'purposeId': 'profilemgmt',
-            'attributeId': 'given_name',
-            'accessTypeId': 'read',
-          },
-          {
-            'purposeId': 'profilemgmt',
-            'attributeId': 'mobile_number',
-            'attributeValue': '+6598786',
-            'accessTypeId': 'read',
-          },
-          {
-            'purposeId': 'profilemgmt',
-            'attributeId': 'mobile_number',
-            'attributeValue': '+651234567',
-            'accessTypeId': 'read',
-          },
-          {
-            'purposeId': 'profilemgmt',
-            'attributeId': 'display_name',
-            'accessTypeId': 'read',
-          },
-        ]);
+      const result = await client.getConsentMetadata([
+        {
+          'purposeId': 'profilemgmt',
+          'attributeId': 'given_name',
+          'accessTypeId': 'read',
+        },
+        {
+          'purposeId': 'profilemgmt',
+          'attributeId': 'mobile_number',
+          'attributeValue': '+6598786',
+          'accessTypeId': 'read',
+        },
+        {
+          'purposeId': 'profilemgmt',
+          'attributeId': 'mobile_number',
+          'attributeValue': '+651234567',
+          'accessTypeId': 'read',
+        },
+        {
+          'purposeId': 'profilemgmt',
+          'attributeId': 'display_name',
+          'accessTypeId': 'read',
+        },
+      ]);
 
-        assert.strictEqual(result.status, 'done',
-            `Result status is not done: ${result.status}`);
-      } catch (error) {
-        assert.fail(`Error thrown:\n${error}`);
+      assert.strictEqual(result.status, 'done',
+          `Result status is not done: ${result.status}`);
+      assert.strictEqual(result.metadata.default.length, 4,
+          `Expected 4 default metadata records`);
+      const expectedResultMap = {
+        'profilemgmt/6.read#': {
+          status: 'ACTIVE',
+        },
+        'profilemgmt/11.read#+6598786': {
+          status: 'NONE',
+        },
+        'profilemgmt/11.read#+651234567': {
+          status: 'ACTIVE',
+        },
+        'profilemgmt/19.read#': {
+          status: 'NOT_ACTIVE',
+        },
+      };
+
+      for (const record of result.metadata.default) {
+        const attrValue = (record.attributeValue != null) ?
+            record.attributeValue : '';
+        const key = record.purposeId + '/' + record.attributeId +
+            '.' + record.accessTypeId + '#' +
+            attrValue;
+
+        assert.strictEqual(record['status'], expectedResultMap[key].status,
+            `Fail: ${JSON.stringify(record)}`);
       }
     });
   });

--- a/test/service/processMetadataTest.js
+++ b/test/service/processMetadataTest.js
@@ -20,11 +20,12 @@ describe('DPCMService', () => {
   describe('#flattenDSPResponse', () => {
     it('should flatten correctly', () => {
       const service = new DPCMService(auth, config.tenantUrl, context);
-      const itemSet = new Set();
-      itemSet.add('marketing/3.default');
-      itemSet.add('marketing/11.default');
-      itemSet.add('eula/.default');
-      itemSet.add('eula2/.default');
+      const itemFilter = {
+        'marketing/3.default': [''],
+        'marketing/11.default': [''],
+        'eula/.default': [''],
+        'eula2/.default': [''],
+      };
       const response = {
         'purposes': {
           'eula': {
@@ -187,9 +188,8 @@ describe('DPCMService', () => {
         },
       };
 
-      debug(`[processConsentMetadata] itemSet:
-          ${new Array(...itemSet).join(' ')}`);
-      service.processConsentMetadata(itemSet, response).then((result) => {
+      debug(`[processConsentMetadata] ${JSON.stringify(itemFilter)}`);
+      service.processConsentMetadata(itemFilter, response).then((result) => {
         debug(`[processConsentMetadata] result:\n${JSON.stringify(result)}`);
       }).catch((err) => {
         debug('Error=' + err);


### PR DESCRIPTION
* Support NOT_ACTIVE as a new status for consent
* Handle the case where the user has both a global consent and an application-specific consent. App-specific consent wins.
* Allow `attributeValue` to be passed into the `items` parameter. This is accordingly filtered.
* Plenty of refactoring